### PR TITLE
Adding feature to use nullable parameters

### DIFF
--- a/src/SequelocityDotNet.Tests/DbCommandExtensionsTests/AddNullableParameterTests.cs
+++ b/src/SequelocityDotNet.Tests/DbCommandExtensionsTests/AddNullableParameterTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Data;
+using NUnit.Framework;
+
+namespace SequelocityDotNet.Tests.DbCommandExtensionsTests
+{
+    [TestFixture]
+    public class AddNullableParameterTests
+    {
+        [Test]
+        [TestCase( null, DbType.Int16 )]
+        [TestCase( null, DbType.AnsiString )]
+        [TestCase( "", DbType.AnsiString )]
+        public void Should_Set_Parameter_Value_To_DBNull_Given_That_Parameter_Is_Null_Or_Empty(object parameterValue, DbType dbType)
+        {
+            // Arrange
+            var dbCommand = TestHelpers.GetDbCommand();
+
+            const string parameterName = "@SuperHeroName";
+
+            // Act
+            dbCommand = dbCommand.AddNullableParameter( parameterName, parameterValue, dbType );
+
+            // Assert
+            Assert.That( dbCommand.Parameters[parameterName].Value == DBNull.Value );
+        }
+
+        [Test]
+        [TestCase( 1234, DbType.Int16 )]
+        [TestCase( "Green Lantern", DbType.AnsiString )]
+        [TestCase( " ", DbType.AnsiString )]
+        public void Should_Set_Parameter_To_The_Given_Value_When_Value_Is_Not_Null( object parameterValue, DbType dbType )
+        {
+            // Arrange
+            var dbCommand = TestHelpers.GetDbCommand();
+
+            const string parameterName = "@SuperHeroName";
+
+            // Act
+            dbCommand = dbCommand.AddNullableParameter( parameterName, parameterValue, dbType );
+
+            // Assert
+            Assert.That( dbCommand.Parameters[parameterName].Value == parameterValue );
+        }
+
+        [Test]
+        [TestCase( "VARCHAR(100)", DbType.AnsiString, "" )]
+        [TestCase( "SMALLINT", DbType.Int16, null )]
+        public void Should_Set_Sql_Parameter_To_Null_When_Null_Or_Empty_Is_Assigned(string sqlDataType, DbType dbType, object parameterValue)
+        {
+            // Arrange
+            const string sql = @"
+DECLARE 
+@SuperHeroName {0} = @pSuperHeroName
+
+SELECT @SuperHeroName as SuperHeroName
+";
+            string formattedSql = string.Format(sql, sqlDataType);
+
+            // Act
+            string result = TestHelpers.GetDatabaseCommand()
+                .SetCommandText( formattedSql )
+                .AddNullableParameter( "@pSuperHeroName", parameterValue, dbType )
+                .ExecuteScalar<string>();
+
+            // Assert
+            Assert.That(result == null);
+        }
+    }
+}

--- a/src/SequelocityDotNet.Tests/SequelocityDotNet.Tests.csproj
+++ b/src/SequelocityDotNet.Tests/SequelocityDotNet.Tests.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DbCommandExtensionsTests\AddNullableParameterTests.cs" />
     <Compile Include="Bugs\Bug5.cs" />
     <Compile Include="DatabaseCommandExtensionsTests\AddParametersTests.cs" />
     <Compile Include="DatabaseCommandExtensionsTests\AddParameterTests.cs" />

--- a/src/SequelocityDotNet/SequelocityDotNet.cs
+++ b/src/SequelocityDotNet/SequelocityDotNet.cs
@@ -608,6 +608,19 @@ namespace SequelocityDotNet
             return databaseCommand;
         }
 
+        /// <summary>Adds a parameter whose default value is <see cref="DBNull"/> when unassigned, to the <see cref="DatabaseCommand" />.</summary>
+        /// <param name="databaseCommand"><see cref="DatabaseCommand" /> instance.</param>
+        /// <param name="parameterName">Parameter name.</param>
+        /// <param name="parameterValue">Parameter value.</param>
+        /// <param name="dbType">Parameter type.</param>
+        /// <returns>The given <see cref="DatabaseCommand" /> instance.</returns>
+        public static DatabaseCommand AddNullableParameter( this DatabaseCommand databaseCommand, string parameterName, object parameterValue, DbType dbType )
+        {
+            databaseCommand.DbCommand.AddNullableParameter( parameterName, parameterValue, dbType );
+
+            return databaseCommand;
+        }
+
         /// <summary>Adds a list of <see cref="DbParameter" />s to the <see cref="DatabaseCommand" />.</summary>
         /// <param name="databaseCommand"><see cref="DatabaseCommand" /> instance.</param>
         /// <param name="dbParameters">List of database parameters.</param>
@@ -1850,6 +1863,28 @@ namespace SequelocityDotNet
             DbParameter parameter = dbCommand.CreateParameter( parameterName, parameterValue, dbType );
 
             dbCommand.Parameters.Add( parameter );
+
+            return dbCommand;
+        }
+
+        /// <summary>Adds a parameter whose default value is <see cref="DBNull" /> when unassigned, to the <see cref="DbCommand" />.</summary>
+        /// <param name="dbCommand"><see cref="DbCommand" /> instance.</param>
+        /// <param name="parameterName">Parameter name.</param>
+        /// <param name="parameterValue">Parameter value.</param>
+        /// <param name="dbType">Parameter type.</param>
+        /// <returns>The given <see cref="DbCommand" /> instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="parameterName" /> parameter is null.</exception>
+        public static DbCommand AddNullableParameter( this DbCommand dbCommand, string parameterName, object parameterValue, DbType dbType )
+        {
+            if ( parameterValue is string 
+                 && string.IsNullOrEmpty( parameterValue.ToString() ) )
+            {
+                parameterValue = null;
+            }
+
+            dbCommand = parameterValue == null
+                ? dbCommand.AddParameter( parameterName, DBNull.Value )
+                : dbCommand.AddParameter( parameterName, parameterValue, dbType );
 
             return dbCommand;
         }


### PR DESCRIPTION
This feature will let users add parameters to the command object that would be defaulted to NULL when unassigned from C#. 

