### PR TITLE
Added generic ExecuteReader extension method and unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+#OSX
+.DS_Store

--- a/src/SequelocityDotNet.Tests.MySql/DatabaseCommandExtensionsTests/ExecuteReaderTests.cs
+++ b/src/SequelocityDotNet.Tests.MySql/DatabaseCommandExtensionsTests/ExecuteReaderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using NUnit.Framework;
 
 namespace SequelocityDotNet.Tests.MySql.DatabaseCommandExtensionsTests
@@ -157,7 +158,7 @@ FROM    SuperHero;
             // Act
             Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
                 .SetCommandText( "SELECT 1" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.IsTrue( wasPreExecuteEventHandlerCalled );
@@ -174,7 +175,7 @@ FROM    SuperHero;
             // Act
             Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
                 .SetCommandText( "SELECT 1" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.IsTrue( wasPostExecuteEventHandlerCalled );
@@ -194,11 +195,289 @@ FROM    SuperHero;
             // Act
             TestDelegate action = () => Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
                 .SetCommandText( "asdf;lkj" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.Throws<global::MySql.Data.MySqlClient.MySqlException>( action );
             Assert.IsTrue( wasUnhandledExceptionEventHandlerCalled );
+        }
+    }
+
+    [TestFixture]
+    public class ExecuteReader_Of_Type_T_Tests
+    {
+        [Test]
+        public void Should_Call_The_DataRecordCall_Func_For_Each_Record_In_The_Result_Set()
+        {
+            // Arrange
+            const string sql = @"
+DROP TEMPORARY TABLE IF EXISTS SuperHero;
+
+CREATE TEMPORARY TABLE SuperHero
+(
+    SuperHeroId     INT             NOT NULL    AUTO_INCREMENT,
+    SuperHeroName	VARCHAR(120)    NOT NULL,
+    PRIMARY KEY ( SuperHeroId )
+);
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+
+            List<object> list;
+
+            // Act
+            list = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( sql )
+                .ExecuteReader<object>( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .ToList();
+
+
+            // Assert
+            Assert.That( list.Count == 2 );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_By_Default()
+        {
+            // Arrange
+            const string sql = @"
+DROP TEMPORARY TABLE IF EXISTS SuperHero;
+
+CREATE TEMPORARY TABLE SuperHero
+(
+    SuperHeroId     INT             NOT NULL    AUTO_INCREMENT,
+    SuperHeroName	VARCHAR(120)    NOT NULL,
+    PRIMARY KEY ( SuperHeroId )
+);
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( sql );
+
+            List<object> list;
+
+            // Act
+            list = databaseCommand
+                .ExecuteReader<object>( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .ToList();
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
+        }
+
+        [Test]
+        public void Should_Keep_The_Database_Connection_Open_If_keepConnectionOpen_Parameter_Was_True()
+        {
+            // Arrange
+            const string sql = @"
+DROP TEMPORARY TABLE IF EXISTS SuperHero;
+
+CREATE TEMPORARY TABLE SuperHero
+(
+    SuperHeroId     INT             NOT NULL    AUTO_INCREMENT,
+    SuperHeroName	VARCHAR(120)    NOT NULL,
+    PRIMARY KEY ( SuperHeroId )
+);
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( sql );
+
+            List<object> list;
+
+            // Act
+            list = databaseCommand
+                .ExecuteReader<object>( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                }, true )
+                .ToList();
+
+            // Assert
+            Assert.That( databaseCommand.DbCommand.Connection.State == ConnectionState.Open );
+
+            // Cleanup
+            databaseCommand.Dispose();
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandPreExecuteEventHandler()
+        {
+            // Arrange
+            bool wasPreExecuteEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandPreExecuteEventHandlers.Add( command => wasPreExecuteEventHandlerCalled = true );
+
+            // Act
+            Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( "SELECT 1" )
+                .ExecuteReader<object>( record => new { } )
+                .ToList();
+
+            // Assert
+            Assert.IsTrue( wasPreExecuteEventHandlerCalled );
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandPostExecuteEventHandler()
+        {
+            // Arrange
+            bool wasPostExecuteEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandPostExecuteEventHandlers.Add( command => wasPostExecuteEventHandlerCalled = true );
+
+            // Act
+            Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( "SELECT 1" )
+                .ExecuteReader<object>( record => new { } )
+                .ToList();
+
+            // Assert
+            Assert.IsTrue( wasPostExecuteEventHandlerCalled );
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandUnhandledExceptionEventHandler()
+        {
+            // Arrange
+            bool wasUnhandledExceptionEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandUnhandledExceptionEventHandlers.Add( ( exception, command ) =>
+            {
+                wasUnhandledExceptionEventHandlerCalled = true;
+            } );
+
+            // Act
+            TestDelegate action = () => Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( "asdf;lkj" )
+                .ExecuteReader<object>( record => new { } )
+                .ToList();
+
+            // Assert
+            Assert.Throws<global::MySql.Data.MySqlClient.MySqlException>( action );
+            Assert.IsTrue( wasUnhandledExceptionEventHandlerCalled );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_If_Iteration_Ends_Before_Full_Enumeration()
+        {
+            // Arrange
+            const string sql = @"
+DROP TEMPORARY TABLE IF EXISTS SuperHero;
+
+CREATE TEMPORARY TABLE SuperHero
+(
+    SuperHeroId     INT             NOT NULL    AUTO_INCREMENT,
+    SuperHeroName	VARCHAR(120)    NOT NULL,
+    PRIMARY KEY ( SuperHeroId )
+);
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( sql );
+
+            // Act
+            databaseCommand
+                .ExecuteReader( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .First();
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_If_Exception_Occurs_During_Iteration()
+        {
+            // Arrange
+            const string sql = @"
+DROP TEMPORARY TABLE IF EXISTS SuperHero;
+
+CREATE TEMPORARY TABLE SuperHero
+(
+    SuperHeroId     INT             NOT NULL    AUTO_INCREMENT,
+    SuperHeroName	VARCHAR(120)    NOT NULL,
+    PRIMARY KEY ( SuperHeroId )
+);
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.MySqlConnectionString )
+                .SetCommandText( sql );
+
+            var iter = databaseCommand.ExecuteReader( record => new
+            {
+                SuperHeroId = record.GetValue( 0 ),
+                SuperHeroName = record.GetValue( 1 )
+            } );
+
+            // Act
+            try
+            {
+                foreach ( var item in iter )
+                {
+                    throw new Exception( "Exception occured during iteration." );
+                }
+            }
+            catch { }
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
         }
     }
 }

--- a/src/SequelocityDotNet.Tests.SQLite/DatabaseCommandExtensionsTests/ExecuteReaderTests.cs
+++ b/src/SequelocityDotNet.Tests.SQLite/DatabaseCommandExtensionsTests/ExecuteReaderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using NUnit.Framework;
 
 namespace SequelocityDotNet.Tests.SQLite.DatabaseCommandExtensionsTests
@@ -23,7 +24,7 @@ CREATE TABLE IF NOT EXISTS SuperHero
 INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
 INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
 
-SELECT  SuperHeroId, /* This should be the only value returned from ExecuteScalar */
+SELECT  SuperHeroId,
         SuperHeroName
 FROM    SuperHero;
 ";
@@ -63,7 +64,7 @@ CREATE TABLE IF NOT EXISTS SuperHero
 INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
 INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
 
-SELECT  SuperHeroId, /* This should be the only value returned from ExecuteScalar */
+SELECT  SuperHeroId,
         SuperHeroName
 FROM    SuperHero;
 ";
@@ -103,7 +104,7 @@ CREATE TABLE IF NOT EXISTS SuperHero
 INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
 INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
 
-SELECT  SuperHeroId, /* This should be the only value returned from ExecuteScalar */
+SELECT  SuperHeroId,
         SuperHeroName
 FROM    SuperHero;
 ";
@@ -142,7 +143,7 @@ FROM    SuperHero;
             // Act
             Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
                 .SetCommandText( "SELECT 1" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.IsTrue( wasPreExecuteEventHandlerCalled );
@@ -159,7 +160,7 @@ FROM    SuperHero;
             // Act
             Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
                 .SetCommandText( "SELECT 1" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.IsTrue( wasPostExecuteEventHandlerCalled );
@@ -179,11 +180,264 @@ FROM    SuperHero;
             // Act
             TestDelegate action = () => Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
                 .SetCommandText( "asdf;lkj" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.Throws<System.Data.SQLite.SQLiteException>( action );
             Assert.IsTrue( wasUnhandledExceptionEventHandlerCalled );
+        }
+    }
+
+    [TestFixture]
+    public class ExecuteReader_Of_Type_T_Tests
+    {
+        [Test]
+        public void Should_Call_The_DataRecordCall_Func_For_Each_Record_In_The_Result_Set()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS SuperHero
+(
+    SuperHeroId     INTEGER         NOT NULL    PRIMARY KEY     AUTOINCREMENT,
+    SuperHeroName	NVARCHAR(120)   NOT NULL,
+    UNIQUE(SuperHeroName)
+);
+
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+
+            List<object> list;
+
+            // Act
+            list = Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( sql )
+                .ExecuteReader<object>( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .ToList();
+
+
+            // Assert
+            Assert.That( list.Count == 2 );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_By_Default()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS SuperHero
+(
+    SuperHeroId     INTEGER         NOT NULL    PRIMARY KEY     AUTOINCREMENT,
+    SuperHeroName	NVARCHAR(120)   NOT NULL,
+    UNIQUE(SuperHeroName)
+);
+
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( sql );
+
+            List<object> list;
+
+            // Act
+            list = databaseCommand
+                .ExecuteReader<object>( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .ToList();
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
+        }
+
+        [Test]
+        public void Should_Keep_The_Database_Connection_Open_If_keepConnectionOpen_Parameter_Was_True()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS SuperHero
+(
+    SuperHeroId     INTEGER         NOT NULL    PRIMARY KEY     AUTOINCREMENT,
+    SuperHeroName	NVARCHAR(120)   NOT NULL,
+    UNIQUE(SuperHeroName)
+);
+
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( sql );
+
+            List<object> list;
+
+            // Act
+            list = databaseCommand
+                .ExecuteReader<object>( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                }, true )
+                .ToList();
+
+            // Assert
+            Assert.That( databaseCommand.DbCommand.Connection.State == ConnectionState.Open );
+
+            // Cleanup
+            databaseCommand.Dispose();
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandPreExecuteEventHandler()
+        {
+            // Arrange
+            bool wasPreExecuteEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandPreExecuteEventHandlers.Add( command => wasPreExecuteEventHandlerCalled = true );
+
+            // Act
+            Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( "SELECT 1" )
+                .ExecuteReader<object>( record => new { } )
+                .ToList();
+
+            // Assert
+            Assert.IsTrue( wasPreExecuteEventHandlerCalled );
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandPostExecuteEventHandler()
+        {
+            // Arrange
+            bool wasPostExecuteEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandPostExecuteEventHandlers.Add( command => wasPostExecuteEventHandlerCalled = true );
+
+            // Act
+            Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( "SELECT 1" )
+                .ExecuteReader<object>( record => new { } )
+                .ToList();
+
+            // Assert
+            Assert.IsTrue( wasPostExecuteEventHandlerCalled );
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandUnhandledExceptionEventHandler()
+        {
+            // Arrange
+            bool wasUnhandledExceptionEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandUnhandledExceptionEventHandlers.Add( ( exception, command ) =>
+            {
+                wasUnhandledExceptionEventHandlerCalled = true;
+            } );
+
+            // Act
+            TestDelegate action = () => Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( "asdf;lkj" )
+                .ExecuteReader<object>( record => new { } )
+                .ToList();
+
+            // Assert
+            Assert.Throws<System.Data.SQLite.SQLiteException>( action );
+            Assert.IsTrue( wasUnhandledExceptionEventHandlerCalled );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_If_Iteration_Ends_Before_Full_Enumeration()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS SuperHero
+(
+    SuperHeroId     INTEGER         NOT NULL    PRIMARY KEY     AUTOINCREMENT,
+    SuperHeroName	NVARCHAR(120)   NOT NULL,
+    UNIQUE(SuperHeroName)
+);
+
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( sql );
+
+            // Act
+            databaseCommand
+                .ExecuteReader( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .First();
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_If_Exception_Occurs_During_Iteration()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS SuperHero
+(
+    SuperHeroId     INTEGER         NOT NULL    PRIMARY KEY     AUTOINCREMENT,
+    SuperHeroName	NVARCHAR(120)   NOT NULL,
+    UNIQUE(SuperHeroName)
+);
+
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Superman' );
+INSERT OR IGNORE INTO SuperHero VALUES ( NULL, 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommandForSQLite( ConnectionStringsNames.SqliteInMemoryDatabaseConnectionString )
+                .SetCommandText( sql );
+
+            var iter = databaseCommand.ExecuteReader( record => new
+            {
+                SuperHeroId = record.GetValue( 0 ),
+                SuperHeroName = record.GetValue( 1 )
+            } );
+
+            // Act
+            try
+            {
+                foreach ( var item in iter )
+                {
+                    throw new Exception( "Exception occured during iteration." );
+                }
+            }
+            catch { }
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
         }
     }
 }

--- a/src/SequelocityDotNet.Tests.SqlServer/DatabaseCommandExtensionsTests/ExecuteReaderTests.cs
+++ b/src/SequelocityDotNet.Tests.SqlServer/DatabaseCommandExtensionsTests/ExecuteReaderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using NUnit.Framework;
 
 namespace SequelocityDotNet.Tests.SqlServer.DatabaseCommandExtensionsTests
@@ -148,7 +149,7 @@ FROM    #SuperHero;
             // Act
             Sequelocity.GetDatabaseCommand( ConnectionStringsNames.SqlServerConnectionString )
                 .SetCommandText( "SELECT 1" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.IsTrue( wasPreExecuteEventHandlerCalled );
@@ -165,7 +166,7 @@ FROM    #SuperHero;
             // Act
             Sequelocity.GetDatabaseCommand( ConnectionStringsNames.SqlServerConnectionString )
                 .SetCommandText( "SELECT 1" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.IsTrue( wasPostExecuteEventHandlerCalled );
@@ -185,11 +186,274 @@ FROM    #SuperHero;
             // Act
             TestDelegate action = () => Sequelocity.GetDatabaseCommand( ConnectionStringsNames.SqlServerConnectionString )
                 .SetCommandText( "asdf;lkj" )
-                .ExecuteReader( record => new Object() );
+                .ExecuteReader( record => { } );
 
             // Assert
             Assert.Throws<System.Data.SqlClient.SqlException>( action );
             Assert.IsTrue( wasUnhandledExceptionEventHandlerCalled );
+        }
+    }
+
+    [TestFixture]
+    public class ExecuteReader_Of_Type_T_Tests
+    {
+        [Test]
+        public void Should_Call_The_DataRecordCall_Func_For_Each_Record_In_The_Result_Set()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE #SuperHero
+(
+    SuperHeroId     INT             NOT NULL    IDENTITY(1,1)   PRIMARY KEY,
+    SuperHeroName	NVARCHAR(120)   NOT NULL
+);
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    #SuperHero;
+";
+
+            List<object> list;
+
+            // Act
+            list = Sequelocity.GetDatabaseCommand(ConnectionStringsNames.SqlServerConnectionString)
+                .SetCommandText(sql)
+                .ExecuteReader<object>(record => new
+                {
+                    SuperHeroId = record.GetValue(0),
+                    SuperHeroName = record.GetValue(1)
+                })
+                .ToList();
+
+
+            // Assert
+            Assert.That(list.Count == 2);
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_By_Default()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE #SuperHero
+(
+    SuperHeroId     INT             NOT NULL    IDENTITY(1,1)   PRIMARY KEY,
+    SuperHeroName	NVARCHAR(120)   NOT NULL
+);
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    #SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand(ConnectionStringsNames.SqlServerConnectionString)
+                .SetCommandText(sql);
+
+            List<object> list;
+
+            // Act
+            list = databaseCommand
+                .ExecuteReader<object>(record => new
+                {
+                    SuperHeroId = record.GetValue(0),
+                    SuperHeroName = record.GetValue(1)
+                })
+                .ToList();
+
+            // Assert
+            Assert.IsNull(databaseCommand.DbCommand);
+        }
+
+        [Test]
+        public void Should_Keep_The_Database_Connection_Open_If_keepConnectionOpen_Parameter_Was_True()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE #SuperHero
+(
+    SuperHeroId     INT             NOT NULL    IDENTITY(1,1)   PRIMARY KEY,
+    SuperHeroName	NVARCHAR(120)   NOT NULL
+);
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    #SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand(ConnectionStringsNames.SqlServerConnectionString)
+                .SetCommandText(sql);
+
+            List<object> list;
+
+            // Act
+            list = databaseCommand
+                .ExecuteReader<object>(record => new
+                {
+                    SuperHeroId = record.GetValue(0),
+                    SuperHeroName = record.GetValue(1)
+                }, true)
+                .ToList();
+
+            // Assert
+            Assert.That(databaseCommand.DbCommand.Connection.State == ConnectionState.Open);
+
+            // Cleanup
+            databaseCommand.Dispose();
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandPreExecuteEventHandler()
+        {
+            // Arrange
+            bool wasPreExecuteEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandPreExecuteEventHandlers.Add(command => wasPreExecuteEventHandlerCalled = true);
+
+            // Act
+            Sequelocity.GetDatabaseCommand(ConnectionStringsNames.SqlServerConnectionString)
+                .SetCommandText("SELECT 1")
+                .ExecuteReader<object>(record => new { })
+                .ToList();
+
+            // Assert
+            Assert.IsTrue(wasPreExecuteEventHandlerCalled);
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandPostExecuteEventHandler()
+        {
+            // Arrange
+            bool wasPostExecuteEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandPostExecuteEventHandlers.Add(command => wasPostExecuteEventHandlerCalled = true);
+
+            // Act
+            Sequelocity.GetDatabaseCommand(ConnectionStringsNames.SqlServerConnectionString)
+                .SetCommandText("SELECT 1")
+                .ExecuteReader<object>(record => new { })
+                .ToList();
+
+            // Assert
+            Assert.IsTrue(wasPostExecuteEventHandlerCalled);
+        }
+
+        [Test]
+        public void Should_Call_The_DatabaseCommandUnhandledExceptionEventHandler()
+        {
+            // Arrange
+            bool wasUnhandledExceptionEventHandlerCalled = false;
+
+            Sequelocity.ConfigurationSettings.EventHandlers.DatabaseCommandUnhandledExceptionEventHandlers.Add((exception, command) =>
+            {
+                wasUnhandledExceptionEventHandlerCalled = true;
+            });
+
+            // Act
+            TestDelegate action = () => Sequelocity.GetDatabaseCommand(ConnectionStringsNames.SqlServerConnectionString)
+                .SetCommandText("asdf;lkj")
+                .ExecuteReader<object>(record => new { })
+                .ToList();
+
+            // Assert
+            Assert.Throws<System.Data.SqlClient.SqlException>(action);
+            Assert.IsTrue(wasUnhandledExceptionEventHandlerCalled);
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_If_Iteration_Ends_Before_Full_Enumeration()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE #SuperHero
+(
+    SuperHeroId     INT             NOT NULL    IDENTITY(1,1)   PRIMARY KEY,
+    SuperHeroName	NVARCHAR(120)   NOT NULL
+);
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    #SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.SqlServerConnectionString )
+                .SetCommandText( sql );
+
+            // Act
+            databaseCommand
+                .ExecuteReader( record => new
+                {
+                    SuperHeroId = record.GetValue( 0 ),
+                    SuperHeroName = record.GetValue( 1 )
+                } )
+                .First();
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
+        }
+
+        [Test]
+        public void Should_Null_The_DbCommand_If_Exception_Occurs_During_Iteration()
+        {
+            // Arrange
+            const string sql = @"
+CREATE TABLE #SuperHero
+(
+    SuperHeroId     INT             NOT NULL    IDENTITY(1,1)   PRIMARY KEY,
+    SuperHeroName	NVARCHAR(120)   NOT NULL
+);
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Superman' );
+
+INSERT INTO #SuperHero ( SuperHeroName )
+VALUES ( 'Batman' );
+
+SELECT  SuperHeroId,
+        SuperHeroName
+FROM    #SuperHero;
+";
+            var databaseCommand = Sequelocity.GetDatabaseCommand( ConnectionStringsNames.SqlServerConnectionString )
+                .SetCommandText( sql );
+
+            var iter = databaseCommand.ExecuteReader( record => new
+            {
+                SuperHeroId = record.GetValue( 0 ),
+                SuperHeroName = record.GetValue( 1 )
+            } );
+
+            // Act
+            try
+            {
+                foreach ( var item in iter )
+                {
+                    throw new Exception( "Exception occured during iteration." );
+                }
+            }
+            catch { }
+
+            // Assert
+            Assert.IsNull( databaseCommand.DbCommand );
         }
     }
 }

--- a/src/SequelocityDotNet.Tests.SqlServer/SequelocityDotNet.Tests.SqlServer.csproj
+++ b/src/SequelocityDotNet.Tests.SqlServer/SequelocityDotNet.Tests.SqlServer.csproj
@@ -76,7 +76,6 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\SequelocityDotNet\SequelocityDotNet.csproj">
       <Project>{92b4ac2e-8f4a-47c7-918e-541fd48c16a0}</Project>


### PR DESCRIPTION
This method provides a deferred reader utilizing C# iterators. This way, it is possible to short-circuit long reads without having to first load the entire data set into a concrete in-memory collection type.

Note: Since this utilizes the deferred execution of iterators, no data is actually read from the data reader until the iterator is enumerated. Further, this implies the iterator should be enumerated only once.
